### PR TITLE
Add Node.js with Docker quickstart

### DIFF
--- a/docs/containers/debug-node.md
+++ b/docs/containers/debug-node.md
@@ -1,44 +1,22 @@
 ---
 Area: containers
 ContentId: F0C800DD-C477-492D-9545-745F570FE042
-PageTitle: Debug a Node.js app running in a Docker container
+PageTitle: Configure & troubleshoot debugging of Node.js apps running in a Docker container
 DateApproved: 12/12/2019
-MetaDescription: Debug a Node.js app running in a Docker container, using Visual Studio Code.
+MetaDescription: How to configure and troubleshoot debugging of Node.js apps running in a Docker container, using Visual Studio Code.
 ---
-# Debugging Node.js within Docker containers
 
-## Walkthrough
+# Common Node.js Debugging Configuration Tasks
 
-Start with an existing Node.js application or create a new one
+When adding Docker files to a Node.js project, tasks and launch configurations are added intended to enable one to debug that application within a Docker container. However, due to the large ecosystem surrounding Node.js, those tasks cannot accommodate every application framework or library, which means that some applications will require additional configuration.
 
-```bash
-> express my-express-app
-> cd my-express-app
-> npm install
-> code .
-```
-
-Add Docker files to the application
-
-Press `kb(workbench.action.showCommands)` to open the command palette and select the `Docker: Add Docker Files to Workspace` command
-
-Select `Node.js`
-
-Select either `Yes` or `No` to include Docker Compose files. (Neither option affects whether you can debug the application in VS Code.)
-
-Enter the port on which the application listens (e.g. typically `3000`)
-
-The Docker extension will add, at minimum, a `.dockerignore` and `Dockerfile` files. It will also add tasks for building and running the application within a Docker container, as well as a launch configuration for debugging the application.
-
-## Common Node.js Debugging Configuration Tasks
-
-### Configuring the Docker container entry point
+## Configuring the Docker container entry point
 
 The Docker extension infers the entry point of the Docker container--that is, the command line for starting the application in a debug mode within the Docker container--via properties of `package.json`.  The extension will first look for the `start` script in the `scripts` object; if found and, if it starts with a `node` or `nodejs` command, it will be used to build the command line for starting the application in debug mode.  If not found or, if not a recognized `node` command, the `main` property in the `package.json` will be used.  If neither is found or recognized, then the user will need to set the `dockerRun.command` property of the `docker-run` task used to start the Docker container.
 
-Some Node.js application frameworks include CLIs for managing the application and used to start the application in the `start` script, which obscure the underlying `node` commands. In these cases, the Docker extension cannot infer the start command and the user must configure it manually.
+Some Node.js application frameworks include CLIs for managing the application and are used to start the application in the `start` script, which obscure the underlying `node` commands. In these cases, the Docker extension cannot infer the start command and it must be configured explicitly.
 
-#### Example: Configuring the entry point for a [Nest.js](https://nestjs.com/) application
+### Example: Configuring the entry point for a [Nest.js](https://nestjs.com/) application
 
 ```json
 {
@@ -60,7 +38,7 @@ Some Node.js application frameworks include CLIs for managing the application an
 }
 ```
 
-#### Example: Configuring the entry point for a [Meteor](https://www.meteor.com/) application
+### Example: Configuring the entry point for a [Meteor](https://www.meteor.com/) application
 
 ```json
 {
@@ -82,21 +60,34 @@ Some Node.js application frameworks include CLIs for managing the application an
 }
 ```
 
+## Automatically launching the browser to the entry page of the application
+
+The Docker extension can automatically launch the browser to the entry point of the application after it has started in the debugger. This feature is enabled by default and configured via the `dockerServerReadyAction` object of the debug configuration in `launch.json`.
+
+This feature depends on several aspects of the application:
+
+ - The application must output logs to the debug console.
+ - The application must log a "server ready" message.
+ - The application must serve a browsable page.
+
+While the default settings may work for an Express.js based application, other Node.js frameworks may require explicit configuration of one or more of those aspects.
+
 ### Ensuring application logs are written to the debug console
 
-The Docker extension can automatically launch the browser to the entry point of the application after it has started in the debugger. (This feature is enabled by default and configured via the `dockerServerReadyAction` object of the debug configuration in `launch.json`.) This feature depends on the application writing its logs to the debug console of the attached debugger.  However, not all logging frameworks will write to the debug console, even when configured to use a console-based logger (as some "console" loggers will actually bypass the console and write directly to `stdout`).
+This feature depends on the application writing its logs to the debug console of the attached debugger.  However, not all logging frameworks will write to the debug console, even when configured to use a console-based logger (as some "console" loggers will actually bypass the console and write directly to `stdout`).
 
 The solution varies depending on the logging framework, but it generally requires creating/adding a logger that *actually* writes to the console.
 
-#### Example: Configuring Express.js applications to write to the debug console
+#### Example: Configuring [Express.js](https://expressjs.com/) applications to write to the debug console
 
-By default, Express.js uses the [`debug`](https://github.com/visionmedia/debug) logging module, which can bypass the console.  This can be resolved by explicitly binding the log function to the console's `debug()` method.
+By default, [Express.js](https://expressjs.com/) uses the [`debug`](https://github.com/visionmedia/debug) logging module, which can bypass the console.  This can be resolved by explicitly binding the log function to the console's `debug()` method.
 
 ```js
 var app = require('../app');
 var debug = require('debug')('my-express-app:server');
 var http = require('http');
 
+// Force logging to the debug console.
 debug.log = console.debug.bind(console);
 ```
 
@@ -124,10 +115,107 @@ Also note that the `debug` logger will not write logs unless enabled via the `DE
 }
 ```
 
-### Automatically launching the browser to the entry page of the application
+### Configuring when the application is "ready"
 
-### Mapping Docker container source files to the local workspace
+The extension determines the application is "ready" to receive HTTP connections when it writes a message of the form `Listening on port <number>` to the debug console, as Express.js does by default.  If the application logs a different
+message, then the `pattern` property of the [`dockerServerReadyAction`]((debug-common.md#dockerServerReadyAction-object-properties)) object of the debug launch configuration should be set to a [JavaScript regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) that matches that message. The regular expression should include a capture group that corresponds to the port on which the application is listening.
 
-## Troubleshooting
+For example, suppose the application logs the following message:
 
-### Docker image fails to build or start due to missing `node_modules` folder
+```js
+function onListening() {
+  var addr = server.address();
+  var bind = typeof addr === 'string'
+    ? 'pipe ' + addr
+    : 'port ' + addr.port;
+  debug('Application has started on ' + bind);
+}
+```
+
+The corresponding `pattern` in the debug launch configuration (in `launch.json`) would be:
+
+```json
+{
+    "configurations": [
+        {
+            "name": "Docker Node.js Launch and Attach",
+            "type": "docker",
+            "request": "launch",
+            "preLaunchTask": "docker-run: debug",
+            "platform": "node",
+            "dockerServerReadyAction": {
+                "pattern": "Application has started on port (\\d+)"
+            }
+        }
+    ]
+}
+```
+
+### Configuring the application entry page
+
+By default, the Docker extension will open the "main" page of the browser (however that is determined by the application).  If the browser should be opened to a specific page, the `uriFormat` property of the [`dockerServerReadyAction`]((debug-common.md#dockerServerReadyAction-object-properties)) object of the debug launch configuration should be set to a Node.js format string, with one string token that indicates where the port should be substituted.
+
+The corresponding `uriFormat` in the debug launch configuration (in `launch.json`) to open the `about.html` page instead of the main page would be:
+
+```json
+{
+    "configurations": [
+        {
+            "name": "Docker Node.js Launch and Attach",
+            "type": "docker",
+            "request": "launch",
+            "preLaunchTask": "docker-run: debug",
+            "platform": "node",
+            "dockerServerReadyAction": {
+                "uriFormat": "http://localhost:%s/about.html"
+            }
+        }
+    ]
+}
+```
+
+## Mapping Docker container source files to the local workspace
+
+By default, the Docker extension assumes the application source files in the running Docker container are located in an `/usr/src/app` folder, and the debugger then maps those files back to the root of the opened workspace, in order to translate breakpoints from the container back to Visual Studio Code.
+
+If the application source files are in a different location (e.g. different Node.js frameworks have different conventions), either within the Docker container or within the opened workspace, then one or both of the `localRoot` and `remoteRoot` properties of the [`node`](debug-node.md#node-object-properties) object of the debug launch configuration should be set the root source locations within the workspace and the Docker container, respectively.
+
+For example, if the application instead resides in `/usr/my-custom-location`, the corresponding `remoteRoot` property would be:
+
+```json
+{
+    "configurations": [
+        {
+            "name": "Docker Node.js Launch and Attach",
+            "type": "docker",
+            "request": "launch",
+            "preLaunchTask": "docker-run: debug",
+            "platform": "node",
+            "node": {
+                "remoteRoot": "/usr/my-custom-location
+            }
+        }
+    ]
+}
+```
+
+# Troubleshooting
+
+## Problem: Docker image fails to build or start due to missing `node_modules` folder
+
+Dockerfiles are often arranged in such a way as to optimize either image build time, image size, or both.  However, not every Node.js application frameworks supports all of the typical Node.js Dockerfile optimizations.  In particular, some frameworks the `node_modules` folder be an immediate subfolder of the application root folder, whereas, the Docker extension scaffolds a Dockerfile where the `node_modules` folder exists at a parent or ancestor level (which is generally allowed by Node.js).
+
+The solution is to simply remove that optimization from the `Dockerfile`:
+
+```dockerfile
+FROM node:10.13-alpine
+ENV NODE_ENV production
+WORKDIR /usr/src/app
+COPY ["package.json", "package-lock.json*", "npm-shrinkwrap.json*", "./"]
+# Remove the `&& mv node_modules ../` from the RUN command:
+# RUN npm install --production --silent && mv node_modules ../
+RUN npm install --production --silent
+COPY . .
+EXPOSE 3000
+CMD npm start
+```

--- a/docs/containers/images/quickstarts/node-add-node.png
+++ b/docs/containers/images/quickstarts/node-add-node.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71331162c4ac694453b0a1f86db28cb6609ed3e595fefaf1e2fe9c09be18d590
+size 76243

--- a/docs/containers/images/quickstarts/node-debug-configuration.png
+++ b/docs/containers/images/quickstarts/node-debug-configuration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0427d69ebe1ea1142a89adcc77340c811a9a212c97849e90e8bf0492409e6565
+size 121108

--- a/docs/containers/images/quickstarts/node-run-browser.png
+++ b/docs/containers/images/quickstarts/node-run-browser.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdfeb37b8fe760d742bc67c388602a7e04bf9d9520480d9dc87bed7b6e0622f2
+size 38529

--- a/docs/containers/images/quickstarts/node-running-container.png
+++ b/docs/containers/images/quickstarts/node-running-container.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:347334de82d4142fcdcdcf305ea30518ed38b3718e602a8345cf7f60aeed4d6c
+size 24736

--- a/docs/containers/images/quickstarts/node-verify-image.png
+++ b/docs/containers/images/quickstarts/node-verify-image.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b698b120dc80f3a296754ee52209de0656fb768cd838e5140472b03b966f7c0e
+size 51445

--- a/docs/containers/quickstart-node.md
+++ b/docs/containers/quickstart-node.md
@@ -99,7 +99,7 @@ When Docker files were added to the application, the Docker extension also added
 
 1. Set a breakpoint in the `get()` handler for the `'/'` route in `routes/index.js`
 
-1. Make sure the `Docker Node.js Launch and Attach` is selected
+1. Make sure the `Docker Node.js Launch and Attach` debugger configuration is selected
 
    ![Selected Docker debug configuration](images/quickstarts/node-debug-configuration.png)
 

--- a/docs/containers/quickstart-node.md
+++ b/docs/containers/quickstart-node.md
@@ -46,7 +46,7 @@ In this guide you will learn how to:
 
 The extension will create `Dockerfile` and `.dockerignore` files. If you elected to include Docker Compose files, `docker-compose.yml` and `docker-compose.debug.yml` will be generated as well. Finally, the extension will create a set of **VS Code tasks** in `.vscode/tasks.json` for building and running the container (in both debug- and release-configurations) and a **launch debug configuration** in `.vscode/launch.json` for debugging the service within the container.
 
-## Start the application
+## Run the service locally
 
 1. Open a terminal (`kb(workbench.action.terminal.toggleTerminal)`)
 1. Enter `npm run start` to start the application:
@@ -55,6 +55,12 @@ The extension will create `Dockerfile` and `.dockerignore` files. If you elected
    > express-app@0.0.0 start /Users/user/code/scratch/express-app
    > node ./bin/www
    ```
+
+1. Open the web browser and navigate to [http://localhost:3000](http://localhost:3000). You should see a page similar to the following:
+
+   ![Application page in browser](images/quickstarts/node-run-browser.png)
+
+1. When done testing, type `Ctrl+C` in the terminal
 
 ## Build the service image
 
@@ -98,10 +104,10 @@ When Docker files were added to the application, the Docker extension also added
    ![Selected Docker debug configuration](images/quickstarts/node-debug-configuration.png)
 
 1. Start debugging (use the `F5` key)
-    - The Docker image for the service is built
-    - The Docker container for the service is run
+    - The Docker image for the service builds
+    - The Docker container for the service runs
     - The browser opens to the (random) port mapped to the service container
-    - The breakpoint in `index.js` is hit
+    - The debugger hits the breakpoint in `index.js`
 
     > Note that, because the debugger attaches *after* the application starts, the breakpoint may missed the first time around; you might have to refresh the browser to see the debugger break on the second try.
     >

--- a/docs/containers/quickstart-node.md
+++ b/docs/containers/quickstart-node.md
@@ -1,0 +1,102 @@
+---
+Order: 7
+Area: containers
+TOCTitle: Node.js
+ContentId: A963901F-BF3F-455F-AD75-AB54EAE72BEF
+PageTitle: Build and run a Node.js app in a container
+DateApproved:
+MetaDescription: Develop, build, and debug a Node.js app in a Docker container, using Visual Studio Code.
+---
+# Build and run a Node.js app in a container
+
+In this guide you will learn how to:
+
+- Create a `Dockerfile` file for a simple Node.js service container
+- Build, run, and verify the functionality of the service
+- Debug the service running within a container
+
+## Prerequisites
+
+- Docker and the VS Code Docker extension must be installed as described on the [[Home page|Home#installation]]
+- [Node.js](https://nodejs.org/) version 10 or later
+
+## Create a Node.js application
+
+1. Open the project folder in VS Code
+1. Open a development command prompt in the project folder and create the project:
+
+   ```bash
+   npx express-generator
+   npm install
+   ```
+
+## Add Docker file to the project
+
+1. Open the Command Palette (`kb(workbench.action.showCommands)`) and use `Docker: Add Docker Files to Workspace...` command:
+
+   // TODO: Add image
+
+1. Select `Node.js` when prompted for the application platform
+1. Select `Yes` or `No` when prompted to include Docker Compose files
+
+   > The Docker Compose files are optional and not used for debugging the application within a container.
+1. Enter `3000` when prompted for the application port
+
+The extension will create the `Dockerfile` and `.dockerignore` files. If Docker Compose files are included, they will be generated as well. Finally, the extension will create a set of **VS Code tasks** for building and running the container (in both debug- and release-configurations), and a **debugging configuration** for launching the container in debug mode.
+
+## Start the application
+
+1. Open a terminal (`kb(workbench.action.terminal.toggleTerminal)`)
+1. Enter `npm run start` to start the application:
+
+   ```output
+   > express-app@0.0.0 start /Users/user/code/scratch/express-app
+   > node ./bin/www
+   ```
+
+## Build the image
+
+1. Open the Command Palette (`kb(workbench.action.showCommands)`) and select the `Docker Images: Build Image...` command
+1. Open the Docker view and verify that the new image is visible in the Images tree:
+
+   // TODO: Add image
+
+## Test the service container
+
+1. Right-click on the image built in the previous step and select `Run` or `Run Interactive`. The container should start and you should be able to see it in the Containers tree:
+
+   // TODO: Add image
+
+1. Open the web browser and navigate to [http://localhost:3000](http://localhost:3000). You should see a page similar to the following:
+
+   // TODO: Add image
+
+1. When done testing, right-click the container in the Containers tree and select `Stop`
+
+## Debug in the service container
+
+When Docker files were added to the application, the Docker extension also added a **VS Code debugger configuration** for debugging the service when it is running inside a container. The extension will automatically detect the protocol and port that the service is using and point the browser to the service, but the application needs to ensure that its output is written to the debug console:
+
+1. Open the `.bin/www` file in the editor
+1. After the `require()` statements shown below, add:
+
+   ```javascript
+   var app = require('../app');
+   var debug = require('debug')('express-guide-2:server');
+   var http = require('http');
+
+   // Add the following line to force the debug logger to write to the debug console.
+   debug.log = console.debug.bind(console);
+   ```
+
+1. Make sure the `Docker Node.js Launch and Attach` is selected
+
+   // TODO: Add image
+
+1. Start debugging (use the `F5` key)
+    - The Docker container for the service is built
+    - The browser opens to the (random) port mapped to the service container
+
+## Next steps
+
+[Learn more about debugging Node.js](/docs/containers/debug-node.md)

--- a/docs/containers/quickstart-node.md
+++ b/docs/containers/quickstart-node.md
@@ -17,12 +17,12 @@ In this guide you will learn how to:
 
 ## Prerequisites
 
-- Both Docker and the VS Code Docker extension must be installed as described on the [[Home page|Home#installation]]
+- Both Docker and the VS Code Docker extension must be installed as described in the [overview](overview.md#installation)
 - [Node.js](https://nodejs.org/) version 10 or later
 
 ## Create an Express Node.js application
 
-1. Create a folder for the project
+1. Create a folder for the project.
 1. Open a development command prompt in the project folder and create the project:
 
    ```bash
@@ -32,23 +32,23 @@ In this guide you will learn how to:
 
 ## Add Docker file to the project
 
-1. Open the project folder in VS Code
+1. Open the project folder in VS Code.
 1. Open the Command Palette (`kb(workbench.action.showCommands)`) and use `Docker: Add Docker Files to Workspace...` command:
 
    ![Add Dockerfile to a Node.js project](images/quickstarts/node-add-node.png)
 
-1. Select `Node.js` when prompted for the application platform
-1. Select either `Yes` or `No` when prompted to include Docker Compose files
+1. Select `Node.js` when prompted for the application platform.
+1. Select either `Yes` or `No` when prompted to include Docker Compose files.
 
    > The Docker Compose files are optional and not used for debugging the application within a container, so either is a valid choice.
 
-1. Enter `3000` when prompted for the application port
+1. Enter `3000` when prompted for the application port.
 
 The extension will create `Dockerfile` and `.dockerignore` files. If you elected to include Docker Compose files, `docker-compose.yml` and `docker-compose.debug.yml` will be generated as well. Finally, the extension will create a set of **VS Code tasks** in `.vscode/tasks.json` for building and running the container (in both debug- and release-configurations) and a **launch debug configuration** in `.vscode/launch.json` for debugging the service within the container.
 
 ## Run the service locally
 
-1. Open a terminal (`kb(workbench.action.terminal.toggleTerminal)`)
+1. Open a terminal (`kb(workbench.action.terminal.toggleTerminal)`).
 1. Enter `npm run start` to start the application:
 
    ```output
@@ -60,11 +60,11 @@ The extension will create `Dockerfile` and `.dockerignore` files. If you elected
 
    ![Application page in browser](images/quickstarts/node-run-browser.png)
 
-1. When done testing, type `Ctrl+C` in the terminal
+1. When done testing, type `Ctrl+C` in the terminal.
 
 ## Build the service image
 
-1. Open the Command Palette (`kb(workbench.action.showCommands)`) and select the `Docker Images: Build Image...` command
+1. Open the Command Palette (`kb(workbench.action.showCommands)`) and select the `Docker Images: Build Image...` command.
 1. Open the Docker view and verify that the new image is visible in the Images tree:
 
    ![Verify Docker image exists](images/quickstarts/node-verify-image.png)
@@ -79,13 +79,13 @@ The extension will create `Dockerfile` and `.dockerignore` files. If you elected
 
    ![Application page in browser](images/quickstarts/node-run-browser.png)
 
-1. When done testing, right-click the container in the Containers tree and select `Stop`
+1. When done testing, right-click the container in the Containers tree and select `Stop`.
 
 ## Debug in the service container
 
-When Docker files were added to the application, the Docker extension also added a **VS Code debugger configuration** in `.vscode/launch.json` for debugging the service when running inside a container. The extension will detect the protocol and port used by the service and point the browser to the service, but the application needs to ensure that its output is written to the debug console:
+When the Docker extension adds files to the application, it also adds a **VS Code debugger configuration** in `.vscode/launch.json` for debugging the service when running inside a container. The extension detects the protocol and port used by the service and points the browser to the service, but make sure the application's output is written to the debug console.
 
-1. Open the `.bin/www` file in the editor
+1. Open the `.bin/www` file in the editor.
 1. After the `require()` statements, add a line that forces the debug logger to write to the debug console, as shown below:
 
    ```javascript
@@ -97,17 +97,17 @@ When Docker files were added to the application, the Docker extension also added
    debug.log = console.debug.bind(console);
    ```
 
-1. Set a breakpoint in the `get()` handler for the `'/'` route in `routes/index.js`
+1. Set a breakpoint in the `get()` handler for the `'/'` route in `routes/index.js`.
 
-1. Make sure the `Docker Node.js Launch and Attach` debugger configuration is selected
+1. Make sure the `Docker Node.js Launch and Attach` debugger configuration is selected.
 
    ![Selected Docker debug configuration](images/quickstarts/node-debug-configuration.png)
 
-1. Start debugging (use the `F5` key)
-    - The Docker image for the service builds
-    - The Docker container for the service runs
-    - The browser opens to the (random) port mapped to the service container
-    - The debugger hits the breakpoint in `index.js`
+1. Start debugging (use the `kb(workbench.action.debug.start)` key).
+    - The Docker image for the service builds.
+    - The Docker container for the service runs.
+    - The browser opens to the (random) port mapped to the service container.
+    - The debugger hits the breakpoint in `index.js`.
 
     > Note that, because the debugger attaches *after* the application starts, the breakpoint may missed the first time around; you might have to refresh the browser to see the debugger break on the second try.
     >

--- a/docs/containers/quickstart-node.md
+++ b/docs/containers/quickstart-node.md
@@ -11,7 +11,7 @@ MetaDescription: Develop, build, and debug a Node.js app in a Docker container, 
 
 In this guide you will learn how to:
 
-- Create a `Dockerfile` file for a simple Node.js service container
+- Create a `Dockerfile` file for an [Express](https://expressjs.com/) Node.js service container
 - Build, run, and verify the functionality of the service
 - Debug the service running within a container
 
@@ -40,11 +40,11 @@ In this guide you will learn how to:
 1. Select `Node.js` when prompted for the application platform
 1. Select either `Yes` or `No` when prompted to include Docker Compose files
 
-   > The Docker Compose files are optional and not used for debugging the application within a container, so either choice is ok.
+   > The Docker Compose files are optional and not used for debugging the application within a container, so either is a valid choice.
 
 1. Enter `3000` when prompted for the application port
 
-The extension will create the `Dockerfile` and `.dockerignore` files. If Docker Compose files are included, they will be generated as well. Finally, the extension will create a set of **VS Code tasks** for building and running the container (in both debug- and release-configurations), and a **debugging configuration** for launching the container in debug mode.
+The extension will create `Dockerfile` and `.dockerignore` files. If you elected to include Docker Compose files, `docker-compose.yml` and `docker-compose.debug.yml` will be generated as well. Finally, the extension will create a set of **VS Code tasks** in `.vscode/tasks.json` for building and running the container (in both debug- and release-configurations) and a **launch debug configuration** in `.vscode/launch.json` for debugging the service within the container.
 
 ## Start the application
 
@@ -56,16 +56,16 @@ The extension will create the `Dockerfile` and `.dockerignore` files. If Docker 
    > node ./bin/www
    ```
 
-## Build the image
+## Build the service image
 
 1. Open the Command Palette (`kb(workbench.action.showCommands)`) and select the `Docker Images: Build Image...` command
 1. Open the Docker view and verify that the new image is visible in the Images tree:
 
    ![Verify Docker image exists](images/quickstarts/node-verify-image.png)
 
-## Test the service container
+## Run the service container
 
-1. Right-click on the image built in the previous step and select `Run` or `Run Interactive`. The container should start and you should be able to see it in the Containers tree:
+1. Right-click on the image built in the previous section and select `Run` or `Run Interactive`. The container should start and you should be able to see it in the Docker Containers tree:
 
    ![Running service container](images/quickstarts/node-running-container.png)
 
@@ -77,28 +77,29 @@ The extension will create the `Dockerfile` and `.dockerignore` files. If Docker 
 
 ## Debug in the service container
 
-When Docker files were added to the application, the Docker extension also added a **VS Code debugger configuration** for debugging the service when it is running inside a container. The extension will automatically detect the protocol and port that the service is using and point the browser to the service, but the application needs to ensure that its output is written to the debug console:
+When Docker files were added to the application, the Docker extension also added a **VS Code debugger configuration** in `.vscode/launch.json` for debugging the service when running inside a container. The extension will detect the protocol and port used by the service and point the browser to the service, but the application needs to ensure that its output is written to the debug console:
 
 1. Open the `.bin/www` file in the editor
-1. After the `require()` statements shown below, add:
+1. After the `require()` statements, add a line that forces the debug logger to write to the debug console, as shown below:
 
    ```javascript
    var app = require('../app');
-   var debug = require('debug')('express-guide-2:server');
+   var debug = require('debug')('express-app:server');
    var http = require('http');
 
    // Add the following line to force the debug logger to write to the debug console.
    debug.log = console.debug.bind(console);
    ```
 
-1. Set a breakpoint in the `get()` handler for the `/` route in `routes/index.js`
+1. Set a breakpoint in the `get()` handler for the `'/'` route in `routes/index.js`
 
 1. Make sure the `Docker Node.js Launch and Attach` is selected
 
    ![Selected Docker debug configuration](images/quickstarts/node-debug-configuration.png)
 
 1. Start debugging (use the `F5` key)
-    - The Docker container for the service is built
+    - The Docker image for the service is built
+    - The Docker container for the service is run
     - The browser opens to the (random) port mapped to the service container
     - The breakpoint in `index.js` is hit
 

--- a/docs/containers/quickstart-node.md
+++ b/docs/containers/quickstart-node.md
@@ -17,12 +17,12 @@ In this guide you will learn how to:
 
 ## Prerequisites
 
-- Docker and the VS Code Docker extension must be installed as described on the [[Home page|Home#installation]]
+- Both Docker and the VS Code Docker extension must be installed as described on the [[Home page|Home#installation]]
 - [Node.js](https://nodejs.org/) version 10 or later
 
-## Create a Node.js application
+## Create an Express Node.js application
 
-1. Open the project folder in VS Code
+1. Create a folder for the project
 1. Open a development command prompt in the project folder and create the project:
 
    ```bash
@@ -32,14 +32,16 @@ In this guide you will learn how to:
 
 ## Add Docker file to the project
 
+1. Open the project folder in VS Code
 1. Open the Command Palette (`kb(workbench.action.showCommands)`) and use `Docker: Add Docker Files to Workspace...` command:
 
-   // TODO: Add image
+   ![Add Dockerfile to a Node.js project](images/quickstarts/node-add-node.png)
 
 1. Select `Node.js` when prompted for the application platform
-1. Select `Yes` or `No` when prompted to include Docker Compose files
+1. Select either `Yes` or `No` when prompted to include Docker Compose files
 
-   > The Docker Compose files are optional and not used for debugging the application within a container.
+   > The Docker Compose files are optional and not used for debugging the application within a container, so either choice is ok.
+
 1. Enter `3000` when prompted for the application port
 
 The extension will create the `Dockerfile` and `.dockerignore` files. If Docker Compose files are included, they will be generated as well. Finally, the extension will create a set of **VS Code tasks** for building and running the container (in both debug- and release-configurations), and a **debugging configuration** for launching the container in debug mode.
@@ -59,17 +61,17 @@ The extension will create the `Dockerfile` and `.dockerignore` files. If Docker 
 1. Open the Command Palette (`kb(workbench.action.showCommands)`) and select the `Docker Images: Build Image...` command
 1. Open the Docker view and verify that the new image is visible in the Images tree:
 
-   // TODO: Add image
+   ![Verify Docker image exists](images/quickstarts/node-verify-image.png)
 
 ## Test the service container
 
 1. Right-click on the image built in the previous step and select `Run` or `Run Interactive`. The container should start and you should be able to see it in the Containers tree:
 
-   // TODO: Add image
+   ![Running service container](images/quickstarts/node-running-container.png)
 
 1. Open the web browser and navigate to [http://localhost:3000](http://localhost:3000). You should see a page similar to the following:
 
-   // TODO: Add image
+   ![Application page in browser](images/quickstarts/node-run-browser.png)
 
 1. When done testing, right-click the container in the Containers tree and select `Stop`
 
@@ -89,13 +91,20 @@ When Docker files were added to the application, the Docker extension also added
    debug.log = console.debug.bind(console);
    ```
 
+1. Set a breakpoint in the `get()` handler for the `/` route in `routes/index.js`
+
 1. Make sure the `Docker Node.js Launch and Attach` is selected
 
-   // TODO: Add image
+   ![Selected Docker debug configuration](images/quickstarts/node-debug-configuration.png)
 
 1. Start debugging (use the `F5` key)
     - The Docker container for the service is built
     - The browser opens to the (random) port mapped to the service container
+    - The breakpoint in `index.js` is hit
+
+    > Note that, because the debugger attaches *after* the application starts, the breakpoint may missed the first time around; you might have to refresh the browser to see the debugger break on the second try.
+    >
+    > You can configure the application to wait for the debugger to attach before starting execution by setting the [`inspectMode`](/docs/containers/reference.md#node-object-properties-docker-run-task) property to `break` in the `docker-run: debug` task in `tasks.json`.
 
 ## Next steps
 


### PR DESCRIPTION
Adds a quickstart document for creating/building/run/debug a Node.js-based service with Docker, using the VS Code Docker extension.  It follows the same basic structure as the quickstart for ASP.NET Core.